### PR TITLE
Passing an array of files is broken

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,8 +146,7 @@ module.exports = (function () {
         globs = helper.ensureArray(globs);
         return Promise.reduce(globs, function (memo, pattern) {
             return glob(pattern).then(function (paths) {
-                memo.concat(paths);
-                return paths;
+                return memo.concat(paths);
             });
         }, []);
     }

--- a/test/input/test2.es6.js
+++ b/test/input/test2.es6.js
@@ -1,0 +1,47 @@
+/**
+ * This is the test2 module for testing jsdoc-x.
+ *
+ * @module test2
+ *
+ * @see {@link https://github.com/onury/jsdoc-x|GitHub Project}
+ *
+ * @license MIT
+ * @copyright 2016, David H. Bronke (whitelynx@gmail.com)
+ */
+
+var Code = require('./code');
+
+/**
+ * This is a test class.
+ *
+ * @memberof module:test2
+ */
+class Test2 {
+
+    /**
+     * Construct an instance of the {@linkcode Test2} class.
+     */
+    constructor() {
+        /**
+         * An instance of the {@linkcode Code} class.
+         *
+         * @type {Code}
+         */
+        this.code = new Code({});
+    }
+
+}
+
+/**
+ * This is a test function.
+ */
+function testFunc() {
+}
+
+/**
+ *  exporting
+ */
+export default {
+    Test2,
+    testFunc
+};

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -58,7 +58,7 @@
 
         it('should parse file (options 2)', function (done) {
             options = {
-                files: './test/input',
+                files: './test/input/code.es6.js',
                 access: null,
                 package: './test/input/package.json',
                 module: false,

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -84,6 +84,35 @@
                 .finally(done);
         });
 
+        it('should parse multiple files', function (done) {
+            options = {
+                files: ['./test/input/code.es6.js', './test/input/test2.es6.js'],
+                encoding: 'utf8',
+                recurse: false,
+                pedantic: false,
+                access: null,
+                package: null,
+                module: true,
+                undocumented: true,
+                undescribed: true,
+                relativePath: null,
+                filter: null
+            };
+            jsdocx.parse(options)
+                .then(function (docs) {
+                    expect(docs).toEqual(jasmine.any(Array));
+                    var result = _.filter(docs, { meta: { filename: 'code.es6.js' } });
+                    expect(result.length).toBeGreaterThan(0);
+                    result = _.filter(docs, { meta: { filename: 'test2.es6.js' } });
+                    expect(result.length).toBeGreaterThan(0);
+                })
+                .catch(function (err) {
+                    expect(Boolean(err)).toEqual(false);
+                    console.log(err.stack || err);
+                })
+                .finally(done);
+        });
+
         it('should parse source code', function (done) {
             options.files = null;
             options.source = '/**\n *  describe\n *  @namespace\n *  @type {Object}\n */\nconst nspace = {};\nclass Test { constructor() {} }';


### PR DESCRIPTION
If you pass an array for the `files` option to `jsdocx.parse()`, it would ignore all but the last item in the array; this fixes that issue.
