### PR TITLE
Check for exact error message from jsdoc

### DIFF
--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -172,7 +172,7 @@ module.exports = (function () {
                 if (code !== 0 || err) {
                     return reject(new Error(err));
                 }
-                if (output.indexOf(' no input ') >= 0) {
+                if (/^There are no input files to process\.\s$/.test(output)) {
                     return reject(new Error(helper.ERR.SOURCE));
                 }
                 resolve(output);


### PR DESCRIPTION
One of my JSDoc comments contained the string `... no input files ...` which was matched by the simple string comparison and thus wrongly detected as an error. Checking with the exact error message should fix this for similar cases.