### PR TITLE
fixes #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/output/*
 tmp
 TODO.md
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Executes the `jsdoc -X` command and parses the output into a Javascript object/a
         </td>
     </tr>
     <tr>
+        <td><b><code>config</code></b></td>
+        <td><code>Object</code></td>
+        <td>
+            Pass in all options as a single object. Overrides all other options. Allows passing custom config options to jsdoc. Default:  <code>{}</code>
+        </td>
+    </tr>
+    <tr>
         <td><b><code>encoding</code><b></td>
         <td><code>String</code></td>
         <td>Encoding to be used when reading source files. Default: <code>"utf8"</code></td>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Parser for outputting a customized Javascript object from documented code via JSDoc's explain (-X) command. ",
   "license": "MIT",
   "author": "Onur Yıldırım <onur@cutepilot.com>",
+  "contributors": [
+    "Justin Beaudry <me@justinbeaudry.dev>"
+  ],
   "repository": "onury/jsdoc-x",
   "main": "src/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -90,29 +90,37 @@ function buildArgs(options) {
 // function creates the conf object to be written to that temp file before
 // passing to jsdoc as a command line argument.
 function buildConf(options) {
-    let opts = options || {};
-
+    const opts = options || {};
+    const config = typeof opts.config === 'object' && !Array.isArray(opts.config)
+        ? opts.config
+        : {};
     // updating default JSDoc configuration.
     // see http://usejsdoc.org/about-configuring-jsdoc.html
-    return {
+    return _.defaultsDeep(config, {
         tags: {
             allowUnknownTags: typeof opts.allowUnknownTags === 'boolean'
                 ? opts.allowUnknownTags
                 : true,
-            dictionaries: !Array.isArray(opts.dictionaries)
-                ? ['jsdoc', 'closure']
-                : opts.dictionaries
+            dictionaries: Array.isArray(opts.dictionaries)
+                ? opts.dictionaries
+                : ['jsdoc', 'closure']
         },
         source: {
-            includePattern: opts.includePattern || '.+\\.js(doc|x)?$',
-            excludePattern: opts.excludePattern || '(^|\\/|\\\\)_'
+            includePattern: typeof opts.includePattern === 'string'
+                ? opts.includePattern
+                : '.+\\.js(doc|x)?$',
+            excludePattern: typeof opts.excludePattern === 'string'
+                ? opts.excludePattern
+                : '(^|\\/|\\\\)_'
         },
-        plugins: !Array.isArray(opts.plugins) ? [] : opts.plugins,
         templates: {
             cleverLinks: false,
             monospaceLinks: false
-        }
-    };
+        },
+        plugins: Array.isArray(opts.plugins)
+            ? opts.plugins
+            : []
+    });
 }
 
 function relativePath(symbol, rPath) {

--- a/src/index.js
+++ b/src/index.js
@@ -91,35 +91,23 @@ function buildArgs(options) {
 // passing to jsdoc as a command line argument.
 function buildConf(options) {
     const opts = options || {};
-    const config = typeof opts.config === 'object' && !Array.isArray(opts.config)
-        ? opts.config
-        : {};
+    const config = _.isPlainObject(opts) ? opts.config : {};
     // updating default JSDoc configuration.
     // see http://usejsdoc.org/about-configuring-jsdoc.html
     return _.defaultsDeep(config, {
         tags: {
-            allowUnknownTags: typeof opts.allowUnknownTags === 'boolean'
-                ? opts.allowUnknownTags
-                : true,
-            dictionaries: Array.isArray(opts.dictionaries)
-                ? opts.dictionaries
-                : ['jsdoc', 'closure']
+            allowUnknownTags: _.isBoolean(opts.allowUnknownTags) ? opts.allowUnknownTags : true,
+            dictionaries: _.isArray(opts.dictionaries) ? opts.dictionaries : ['jsdoc', 'closure']
         },
         source: {
-            includePattern: typeof opts.includePattern === 'string'
-                ? opts.includePattern
-                : '.+\\.js(doc|x)?$',
-            excludePattern: typeof opts.excludePattern === 'string'
-                ? opts.excludePattern
-                : '(^|\\/|\\\\)_'
+            includePattern: _.isString(opts.includePattern) ? opts.includePattern : '.+\\.js(doc|x)?$',
+            excludePattern: _.isString(opts.excludePattern) ? opts.excludePattern : '(^|\\/|\\\\)_'
         },
         templates: {
             cleverLinks: false,
             monospaceLinks: false
         },
-        plugins: Array.isArray(opts.plugins)
-            ? opts.plugins
-            : []
+        plugins: _.isArray(opts.plugins) ? opts.plugins : []
     });
 }
 

--- a/test/conf.spec.js
+++ b/test/conf.spec.js
@@ -4,27 +4,32 @@
 const jsdocx = require('../src/index');
 
 describe('JSDoc configuration options', () => {
-    var options = {
-        encoding: 'utf8',
-        recurse: false,
-        pedantic: false,
-        access: null,
-        package: null,
-        module: true,
-        undocumented: true,
-        undescribed: true,
-        relativePath: null,
-        filter: null,
-        allowUnknownTags: true,
-        dictionaries: ['jsdoc', 'closure'],
-        includePattern: '.+\\.js(doc|x)?$',
-        excludePattern: '(^|\\/|\\\\)_',
-        plugins: [],
-        output: {
-            path: './test/output/plugins-test.json',
-            indent: true
-        }
-    };
+    let options;
+    // provision options per test so tests can be run in any order and not conflict
+    beforeEach(() => {
+        options = {
+            encoding: 'utf8',
+            recurse: false,
+            pedantic: false,
+            access: null,
+            package: null,
+            module: true,
+            undocumented: true,
+            undescribed: true,
+            relativePath: null,
+            filter: null,
+            allowUnknownTags: true,
+            dictionaries: ['jsdoc', 'closure'],
+            includePattern: '.+\\.js(doc|x)?$',
+            excludePattern: '(^|\\/|\\\\)_',
+            plugins: [],
+            output: {
+                path: './test/output/plugins-test.json',
+                indent: true
+            },
+            config: {}
+        };
+    });
 
     // beforeAll(function () {});
 
@@ -45,6 +50,57 @@ describe('JSDoc configuration options', () => {
         jsdocx.parse(options)
             .then(docs => {
                 // below means allowUnknownTags passed the test
+                expect(docs).toEqual(jasmine.any(Array));
+            })
+            .catch(err => {
+                expect(Boolean(err)).toEqual(false);
+                console.log(err.stack || err);
+            })
+            .finally(done);
+    });
+
+    it('config.tags.allowUnknownTags should override options.allowUnknownTags and throw', done => {
+        options.source = '/**\n *  describe\n *  @unknowntag\n *  @type {Object}\n */\nconst a = {};';
+        // config.tags should override allowUnknownTags
+        options.config.tags = {
+            allowUnknownTags: false
+        };
+        jsdocx.parse(options)
+            .catch(err => {
+                expect(err).toBeDefined();
+            })
+            .finally(done);
+    });
+
+    it('config.tags.allowUnknownTags should override options.allowUnknownTags and not throw', done => {
+        options.source = '/**\n *  describe\n *  @unknowntag\n *  @type {Object}\n */\nconst a = {};';
+        options.allowUnknownTags = false;
+        // config.tags should override allowUnknownTags
+        options.config.tags = {
+            allowUnknownTags: true
+        };
+        jsdocx.parse(options)
+            .then(docs => {
+                // below means allowUnknownTags passed the test
+                expect(docs).toEqual(jasmine.any(Array));
+            })
+            .catch(err => {
+                expect(Boolean(err)).toEqual(false);
+                console.log(err.stack || err);
+            })
+            .finally(done);
+    });
+
+    // allows passing custom options to jsdoc
+    fit('setting config.custom object should not throw', done => {
+        options.source = '/**\n *  describe\n *  @type {Object}\n */\nconst a = {};';
+        options.config.custom = {
+            key: 'value'
+        };
+        // an update (keep: true for `tmp`) to allow parsing the config to ensure `custom`
+        // is set properly would be helpful in determining if this works as expected
+        jsdocx.parse(options)
+            .then(docs => {
                 expect(docs).toEqual(jasmine.any(Array));
             })
             .catch(err => {

--- a/test/conf.spec.js
+++ b/test/conf.spec.js
@@ -92,7 +92,7 @@ describe('JSDoc configuration options', () => {
     });
 
     // allows passing custom options to jsdoc
-    fit('setting config.custom object should not throw', done => {
+    it('setting config.custom object should not throw', done => {
         options.source = '/**\n *  describe\n *  @type {Object}\n */\nconst a = {};';
         options.config.custom = {
             key: 'value'


### PR DESCRIPTION
This PR introduces two refactors, and some additional unit tests:

- refactors `buildConf` to support a top-level `config` object to be passed which: overrides all options, and allows passing custom options to jsdoc
- slight refactor to conf.spec.js to use beforeEach when setting `options` to prevent tests from overwriting global state. This adds support for running tests in parallel and ensures a clean global state for each test run.
- adds 3 additional unit tests to support the `config` option
  - test that `options.config.tags.allowUnknownTags` overrides `options.allowUnknownTags` and throws
 - test that `options.config.tags.allowUnknownTags` overrides `options.allowUnknownTags` and does not throw
- test that setting `options.config.custom` with a property does not cause unexpected behavior

For the latter test, it would be nice to be able to inspect the output config (`keep: true` for the config). I manually set this to inspect and noted the configuration was as expected, but refactoring to support this felt like too large a changeset.

> You can just use _.defaultsDeep() instead of using _.extend() and putting a conditional on each nested object.

Instead of putting conditionals on each object, `config` is a top-level override in that any options passed into `config` will override other settings. This could be potentially confusing to users unless documented well but seemed to be the simplest way with the smallest changeset to accomplish allowing custom options to be passed.

I'm waiting to update documentation and package version until I get some feedback from you @onury.